### PR TITLE
Enhancement: expose defaults in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,12 @@ Just include ``jgt_tools`` in your package VirtualEnv, and you'll have access to
 
 Details for each script can be found by calling with the ``--help`` flag.
 
+Default values for each are:
+
+.. csv-table:: Default Command values
+   :header: "Command Set", "Command"
+   :file: ../data/defaults.csv
+
 Configuration
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Details for each script can be found by calling with the ``--help`` flag.
 Default values for each are:
 
 .. csv-table:: Default Command values
-   :header: "Command Set", "Command"
+   :header: "Configuration Key", "Command"
    :file: ../data/defaults.csv
 
 Configuration

--- a/data/defaults.csv
+++ b/data/defaults.csv
@@ -1,0 +1,6 @@
+env_setup_commands,pip install --upgrade pip<19
+env_setup_commands,poetry install
+env_setup_commands,pre-commit install
+self_check_commands,pre-commit run -a
+run_tests_commands,python -m pytest
+doc_build_types,api

--- a/data/defaults.csv
+++ b/data/defaults.csv
@@ -1,6 +1,6 @@
-env_setup_commands,pip install --upgrade pip<19
+env_setup_commands,poetry run pip install --upgrade pip<19
 env_setup_commands,poetry install
-env_setup_commands,pre-commit install
-self_check_commands,pre-commit run -a
-run_tests_commands,python -m pytest
+env_setup_commands,poetry run pre-commit install
+self_check_commands,poetry run pre-commit run -a
+run_tests_commands,poetry run python -m pytest
 doc_build_types,api

--- a/jgt_tools/utils.py
+++ b/jgt_tools/utils.py
@@ -1,4 +1,6 @@
 """Shared util functions."""
+from collections import defaultdict
+import csv
 from pathlib import Path
 import shlex
 import subprocess
@@ -19,16 +21,16 @@ def execute_command_list(commands_to_run, verbose=True):
         subprocess.run(shlex.split(command), check=True)
 
 
-_DEFAULT_CONFIGS = {
-    "env_setup_commands": [
-        "pip install --upgrade pip<19",
-        "poetry install",
-        "pre-commit install",
-    ],
-    "self_check_commands": ["pre-commit run -a"],
-    "run_tests_commands": [f"{sys.executable} -m pytest"],
-    "doc_build_types": ["api"],
-}
+_DEFAULT_CONFIGS: defaultdict = defaultdict(list)
+
+
+def _load_defaults():
+    with open("data/defaults.csv") as f:
+        for group, cmd in csv.reader(f):
+            _DEFAULT_CONFIGS[group].append(cmd.replace("python", sys.executable))
+
+
+_load_defaults()
 
 
 def load_configs():

--- a/jgt_tools/utils.py
+++ b/jgt_tools/utils.py
@@ -4,7 +4,6 @@ import csv
 from pathlib import Path
 import shlex
 import subprocess
-import sys
 
 import tomlkit
 
@@ -27,7 +26,7 @@ _DEFAULT_CONFIGS: defaultdict = defaultdict(list)
 def _load_defaults():
     with open("data/defaults.csv") as f:
         for group, cmd in csv.reader(f):
-            _DEFAULT_CONFIGS[group].append(cmd.replace("python", sys.executable))
+            _DEFAULT_CONFIGS[group].append(cmd)
 
 
 _load_defaults()


### PR DESCRIPTION
Move the default command values to a csv so that we can pull them into the code as well as displaying them in the README file.

Visible in the docs [here](https://bradsbrown.github.io/jgt_tools/#id1)