### PR TITLE
Enhancement: move to pathlib where approriate

### DIFF
--- a/jgt_tools/docs/build_docs.py
+++ b/jgt_tools/docs/build_docs.py
@@ -1,7 +1,7 @@
 """Build the documentation for a package."""
 import argparse
-import glob
 import os
+from pathlib import Path
 import shutil
 import subprocess
 
@@ -69,13 +69,13 @@ def build():
 
     # Copy over all the top level rST files so we don't
     # have to keep a duplicate list here.
-    for filename in glob.iglob("*.rst"):
+    for filename in Path().glob("*.rst"):
         shutil.copy(filename, DOCS_WORKING_DIRECTORY)
 
-    for filename in glob.iglob(os.path.join("sphinx_docs", "*")):
+    for filename in Path("sphinx_docs").glob("*"):
         shutil.copy(filename, DOCS_WORKING_DIRECTORY)
 
-    os.environ["PYTHONPATH"] = os.path.curdir
+    os.environ["PYTHONPATH"] = str(Path.cwd())
     subprocess.check_call(
         [
             "poetry",

--- a/sphinx_docs/conf.py
+++ b/sphinx_docs/conf.py
@@ -1,14 +1,12 @@
 """Configure sphinx for package doc publication."""
 import os
+from pathlib import Path
 
 import tomlkit
 
 PYPROJECT_FILE = "pyproject.toml"
 EXPLANATION = "- needed to extract version information."
-file_path = os.path.join(
-    os.path.abspath(os.path.join(__file__, os.path.pardir, os.path.pardir)),
-    PYPROJECT_FILE,
-)
+file_path = Path(__file__).parents[1] / PYPROJECT_FILE
 
 try:
     with open(file_path) as f:


### PR DESCRIPTION
Replace file path handling from `os.path` to use `pathlib.Path` where applicable.