### PR TITLE
Enhancement: Mirror xtrace

### DIFF
--- a/jgt_tools/utils.py
+++ b/jgt_tools/utils.py
@@ -16,7 +16,7 @@ def execute_command_list(commands_to_run, verbose=True):
     """
     for command in commands_to_run:
         if verbose:
-            print(command)
+            print(f"+{command}")
         subprocess.run(shlex.split(command), check=True)
 
 


### PR DESCRIPTION
Mirror the behavior of `set -o xtrace` by prepending a `+` to each
command that is run when `verbose` is set.

This is an opinionated PR so you can vote with your review.