### PR TITLE
Enhancement: streamline bootstrap install

### DIFF
--- a/env_setup.py
+++ b/env_setup.py
@@ -7,5 +7,10 @@ try:
 except ModuleNotFoundError:
     import subprocess
 
-    subprocess.check_call(["poetry", "install"])
+    # if jgt_tools is not importable, one of two things has happened:
+    # either you are inside a "naked" virtualenv,
+    # or you are not inside the virutalenv at all.
+    # Installing and calling `env-setup` via subcommand and `poetry run`
+    # will ensure the "right thing" happens in either situation.
+    subprocess.check_call(["poetry", "run", "pip", "install", "jgt_tools"])
     subprocess.check_call(["poetry", "run", "env-setup"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jgt_tools"
-version = "0.1.2"
+version = "0.1.3"
 description = "A collection of tools for commmon package scripts"
 authors = ["Brad Brown <brad@bradsbrown.com>"]
 license = "MIT"


### PR DESCRIPTION
Rather than running a full `poetry install` followed by a second run within the set of `env-setup` commands, `poetry run {anything}` will merely create the poetry venv (if not already running in one) without installing any reqs, then run the command.

This change allows us to do the _bare minimum_ to make `env-setup` available so that it can do all the rest of the setup work (thus preventing any double-calls to run a `poetry install`, for example).