### PR TITLE
Enhancement: TravisCI-Slack Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,29 @@
 language: python
 python:
-  - "3.6"
-
+- '3.6'
 branches:
   only:
-    - master
-
+  - master
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install graphviz
-  - pip install poetry
-
+- sudo apt-get update
+- sudo apt-get install graphviz
+- pip install poetry
 install:
-  - ./env_setup.py
-
+- "./env_setup.py"
 script:
-  - poetry run self-check
-  - poetry run build-docs
-
+- poetry run self-check
+- poetry run build-docs
 before_deploy:
-  - poetry config http-basic.pypi $PYPI_USER $PYPI_PASS
-  - poetry build
-
+- poetry config http-basic.pypi $PYPI_USER $PYPI_PASS
+- poetry build
 deploy:
-  - provider: pages
-    skip_cleanup: true
-    github_token: $GH_TOKEN
-    local_dir: docs/
-  - provider: script
-    script: poetry publish
-    skip_cleanup: true
+- provider: pages
+  skip_cleanup: true
+  github_token: "$GH_TOKEN"
+  local_dir: docs/
+- provider: script
+  script: poetry publish
+  skip_cleanup: true
+notifications:
+  slack:
+    secure: qmwbPwE71/wrhmiJ4fQaDx0DqSWqlGZm5RCM5DL8B8EM9m16/+3kJDFzgV1plodjOOJ8R3ZHV7E0fZkVqjDiBCxY/6ptiSnqkixLfHMasEXePG2jCCFwDVj+6im477aH0/ahXNzv72zSevrRXOufAxTCpPa1SsvicmBBedSlPU/fhE+ekecPnICCiai6G8wlV9FqoCsVkwYoFiuwZ4ScCroTlVe04ACNSQ/bVyKB536vE71RWs8jajHVpZpccsy0LkXT4RaSGmYmnJn3tJvPBVRJMu2mfys0bqnufs5CVhh0UOO9SzdnpBQ+GBYldokPhgTIoemltTqk1/XKtbhvcSCaUTKvbn3LTOlq+8I6l6ps52HEp6kSzQfpbyAxHV2WiYLhW0woJhRXsVQfwHeA+PhhNryWtvCKsrcNZn9PVQb8eheqzc3qTyfMEfZ1U9ddYO4jBryHYgn8J36xN2S1jQ5WHJoFe3L26ytPC0lJ0JGXJTbAvs589Xy1yCSzKtHjOZ1eLCKNHpQvugVVknJLGvDNEQuIYkx8rnKIvzrQLcPg7KySKzmvrGPQhNyiXVUpeHIat317s1E0HinP+fOZcaA3oJn/x+O5aNraw3tJCo96HpeWh/+tuSavTdzm/O3tR5VMtjtQXHAHCU3RLaxZHF96Tm9MQ0Dk4fh83eVyCDc=


### PR DESCRIPTION
Have TravisCI post updates in Slack like GitHub does.

Note: I utilized the official `travis` CLI to encrypt the notification
string based on their recommendations since the token that would be
included in the file is only semi-secret. However, as a result, it also
auto-linted the file.