### PR TITLE
Fix: de-pluralize

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Available values are:
 
 For example::
 
-    [tools.jgt_tools]
+    [tool.jgt_tools]
     env_setup_commands = [
         "poetry install",
         "poetry run pip install other_package",


### PR DESCRIPTION
Plurality is hard, but the `tool` in the section header should definitely be singular.