### PR TITLE
Opinions Needed: Enhancement pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
     - repo: https://github.com/ambv/black
-      rev: stable
+      rev: 19.3b0
       hooks:
           - id: black
             language_version: python3
     - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v0.701
+      rev: v0.720
       hooks:
           - id: mypy
             exclude: tests/data/*
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v2.2.3
+      rev: v2.3.0
       hooks:
           - id: flake8
             exclude: ^build/*

--- a/jgt_tools/data/defaults.csv
+++ b/jgt_tools/data/defaults.csv
@@ -1,6 +1,7 @@
 env_setup_commands,poetry run pip install --upgrade pip<19
 env_setup_commands,poetry install
 env_setup_commands,poetry run pre-commit install
+env_setup_commands,poetry run pre-commit autoupdate,in case of a pre-exsiting pre-commit environment that is stale
 self_check_commands,poetry run pre-commit run -a
 run_tests_commands,poetry run python -m pytest -vvv
 doc_build_types,api

--- a/jgt_tools/utils.py
+++ b/jgt_tools/utils.py
@@ -31,7 +31,9 @@ _DEFAULT_CONFIGS: defaultdict = defaultdict(list)
 
 def _load_defaults():
     with DEFAULTS_FILE.open() as f:
-        for group, cmd in csv.reader(f):
+        # Allow arbitrary comments to follow the command as columns,
+        # since CSV files don't have a comment to end of line feature.
+        for group, cmd, *comments in csv.reader(f):
             _DEFAULT_CONFIGS[group].append(cmd)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jgt_tools"
-version = "0.2.3"
+version = "0.2.4"
 description = "A collection of tools for commmon package scripts"
 authors = ["Brad Brown <brad@bradsbrown.com>"]
 license = "MIT"


### PR DESCRIPTION
Enhancement: do a pre-commit autoupdate when setting up the environment.
Built on PR #26, so marking DNM until that PR lands and I can rebase this one.
None-the-less, putting this up for review to get team feedback on the approach and to see if there is a better way to handle things. And/or a better way to comment/document the defaults.csv file contents.

This solves a problem I ran into with tableread where my clone hadn't been used in a while and the pre-commit hooks got stale and failed to run.
While it looks like pre-commit is run in the poetry venv, it actually has it's own separate venv that it uses for the tools, and that is what had gotten stale.
Because pre-commit hides that venv pretty well, it's easy to forget about when coming back to a repo after a month or two.
