### PR TITLE
More flexible build docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,8 @@ Available values are:
   under the ``self-check`` call
 - ``run_tests_commands`` - a list of commands to be run
   under the ``run-tests`` call
-- ``doc_build_types`` - a list of types for doc construction:
-  - ``api`` is currently the only supported option
+- ``build_docs_commands`` - a list of commands to be run
+  under the ``build-docs`` call
 
 For example::
 
@@ -62,10 +62,10 @@ For example::
         "poetry run pip install other_package",
         "./my_custom_setup_script.sh"
     ]
-    doc_build_types = []
+    build_docs_commands = []
 
 would run your specified commands for ``env-setup``
-and skip the ``api`` doc builder.
+and skip the default api doc builder.
 
 In addition,
 the function to verify which files are relevant to ``check-version``

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,33 @@ For example::
 would run your specified commands for ``env-setup``
 and skip the default api doc builder.
 
+build_docs_commands
+~~~~~~~~~~~~~~~~~~~
+
+Specifically for ``build_docs_commands``,
+there are some variables
+that can be used to aid in documentation building,
+using Python-style curly-brace formatting::
+
+    BASE_DIR: Root library directory
+    PACKAGE_NAME: Folder name containing package
+    DOCS_WORKING_DIRECTORY: Temporary directory where docs are built (needed for Sphinx)
+    DOCS_OUTPUT_DIRECTORY: Final directory where docs are saved
+
+For example::
+
+    [tool.jgt_tools]
+    build_docs_commands = [
+        "poetry run sphinx-apidoc --output-dir {DOCS_WORKING_DIRECTORY} --no-toc --force --module-first {PACKAGE_NAME}
+    ]
+
+builds the Sphinx API docs for the current package
+and stores the output files
+in the temporary working directory.
+
+check-version
+~~~~~~~~~~~~~
+
 In addition,
 the function to verify which files are relevant to ``check-version``
 can be customized.

--- a/jgt_tools/data/defaults.csv
+++ b/jgt_tools/data/defaults.csv
@@ -3,4 +3,4 @@ env_setup_commands,poetry install
 env_setup_commands,poetry run pre-commit install
 self_check_commands,poetry run pre-commit run -a
 run_tests_commands,poetry run python -m pytest -vvv
-doc_build_types,api
+build_docs_commands,poetry run sphinx-apidoc --output-dir {DOCS_WORKING_DIRECTORY} --no-toc --force --module-first {PACKAGE_NAME}

--- a/jgt_tools/docs/build_docs.py
+++ b/jgt_tools/docs/build_docs.py
@@ -4,12 +4,11 @@ import email.utils
 import itertools
 import os
 from pathlib import Path
-import shlex
 import shutil
 import subprocess
 import time
 
-from ..utils import CONFIGS, get_pyproject_config
+from ..utils import CONFIGS, execute_command_list, get_pyproject_config
 from .sample_conf import CONF_PY, MARKDOWN, TYPE_HINTS
 
 
@@ -23,10 +22,7 @@ DOCS_WORKING_DIRECTORY = "_docs"
 
 def _build_docs():
     print(f"Building {PACKAGE_NAME} API docs")
-    for command in __commands_to_run:
-        command = command.format(**globals())
-        print(command)
-        subprocess.check_call(shlex.split(command), cwd=BASE_DIR)
+    execute_command_list([x.format(**globals()) for x in __commands_to_run])
 
 
 def _build_conf():

--- a/jgt_tools/docs/build_docs.py
+++ b/jgt_tools/docs/build_docs.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import shutil
 import subprocess
 import time
+import warnings
 
 from ..utils import CONFIGS, execute_command_list, get_pyproject_config
 from .sample_conf import CONF_PY, MARKDOWN, TYPE_HINTS
@@ -22,6 +23,16 @@ DOCS_WORKING_DIRECTORY = "_docs"
 
 def _build_docs():
     print(f"Building {PACKAGE_NAME} API docs")
+    pyproject = get_pyproject_config()
+    tools = pyproject["tool"]["jgt_tools"]
+    if "doc_build_types" in tools:
+        message = (
+            "The use of doc_build_types is deprecated and may be removed in a "
+            "future version of the library. Use build_docs_commands instead."
+        )
+        warnings.warn(message, FutureWarning)
+        if tools["doc_build_types"] == [] and "build_docs_commands" not in tools:
+            return
     execute_command_list([x.format(**globals()) for x in __commands_to_run])
 
 

--- a/jgt_tools/docs/build_docs.py
+++ b/jgt_tools/docs/build_docs.py
@@ -24,7 +24,7 @@ DOCS_WORKING_DIRECTORY = "_docs"
 def _build_docs():
     print(f"Building {PACKAGE_NAME} API docs")
     pyproject = get_pyproject_config()
-    tools = pyproject["tool"]["jgt_tools"]
+    tools = pyproject["tool"].get("jgt_tools") or {}
     if "doc_build_types" in tools:
         message = (
             "The use of doc_build_types is deprecated and may be removed in a "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jgt_tools"
-version = "0.2.4"
+version = "0.3.0"
 description = "A collection of tools for commmon package scripts"
 authors = ["Brad Brown <brad@bradsbrown.com>"]
 license = "MIT"


### PR DESCRIPTION
The old build-docs-by-type never really had the flexibility that we had
hoped and there was a need to handle custom API docs builder. This PR
makes the docs builder work more in line with the other commands where a
reasonable default is set but a user can add a list of commands in the
pyproject.toml file.