### PR TITLE
Cleaner dependency management

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,15 @@ and you'll have access to these CLI calls:
 
 Details for each script can be found by calling with the ``--help`` flag.
 
+.. tip::
+   In order to keep the environment as clean as possible,
+   JGT Tools will only install the libraries needed to start the tool itself.
+   However, several of the default commands
+   rely on additional libraries.
+   When ``env-setup`` is run for the first time,
+   it will check to see if each set of commands is still default,
+   and if so, install the libraries those commands need.
+
 
 run-tests
 ---------

--- a/env_setup.py
+++ b/env_setup.py
@@ -12,5 +12,7 @@ except ModuleNotFoundError:
     # or you are not inside the virutalenv at all.
     # Installing and calling `env-setup` via subcommand and `poetry run`
     # will ensure the "right thing" happens in either situation.
-    subprocess.check_call(["poetry", "run", "pip", "install", "jgt_tools"])
+    proc = subprocess.run(["poetry", "version"], stdout=subprocess.PIPE)
+    package_name = "." if proc.stdout.split()[0] == b"jgt-tools" else "jgt_tools"
+    subprocess.check_call(["poetry", "run", "pip", "install", package_name])
     subprocess.check_call(["poetry", "run", "env-setup"])

--- a/jgt_tools/data/defaults.csv
+++ b/jgt_tools/data/defaults.csv
@@ -3,7 +3,7 @@ env_setup_commands,poetry install
 env_setup_commands,poetry run pre-commit install
 self_check_commands,poetry run pre-commit run -a
 run_tests_commands,poetry run python -m pytest -vvv
-build_docs_commands,find . -name \*.rst -maxdepth 1 -exec cp {{}} {DOCS_WORKING_DIRECTORY} \;
+build_docs_commands,find . -maxdepth 1 -name \*.rst -exec cp {{}} {DOCS_WORKING_DIRECTORY} \;
 build_docs_commands,poetry run sphinx-apidoc --output-dir {DOCS_WORKING_DIRECTORY} --no-toc --force --module-first {PACKAGE_NAME}
 build_docs_commands,cp {BASE_DIR}/.jgt_tools.index {BASE_DIR}/{DOCS_WORKING_DIRECTORY}/index.rst
 build_docs_commands,poetry run sphinx-build -c {DOCS_WORKING_DIRECTORY} -aEW {DOCS_WORKING_DIRECTORY} {DOCS_OUTPUT_DIRECTORY}

--- a/jgt_tools/data/defaults.csv
+++ b/jgt_tools/data/defaults.csv
@@ -3,4 +3,7 @@ env_setup_commands,poetry install
 env_setup_commands,poetry run pre-commit install
 self_check_commands,poetry run pre-commit run -a
 run_tests_commands,poetry run python -m pytest -vvv
+build_docs_commands,find . -name \*.rst -maxdepth 1 -exec cp {{}} {DOCS_WORKING_DIRECTORY} \;
 build_docs_commands,poetry run sphinx-apidoc --output-dir {DOCS_WORKING_DIRECTORY} --no-toc --force --module-first {PACKAGE_NAME}
+build_docs_commands,cp {BASE_DIR}/.jgt_tools.index {BASE_DIR}/{DOCS_WORKING_DIRECTORY}/index.rst
+build_docs_commands,poetry run sphinx-build -c {DOCS_WORKING_DIRECTORY} -aEW {DOCS_WORKING_DIRECTORY} {DOCS_OUTPUT_DIRECTORY}

--- a/jgt_tools/data/defaults.csv
+++ b/jgt_tools/data/defaults.csv
@@ -3,6 +3,7 @@ env_setup_commands,poetry install
 env_setup_commands,poetry run pre-commit install
 self_check_commands,poetry run pre-commit run -a
 run_tests_commands,poetry run python -m pytest -vvv
+build_docs_commands,echo "Building {PACKAGE_NAME} docs"
 build_docs_commands,find . -maxdepth 1 -name \*.rst -exec cp {{}} {DOCS_WORKING_DIRECTORY} \;
 build_docs_commands,poetry run sphinx-apidoc --output-dir {DOCS_WORKING_DIRECTORY} --no-toc --force --module-first {PACKAGE_NAME}
 build_docs_commands,cp {BASE_DIR}/.jgt_tools.index {BASE_DIR}/{DOCS_WORKING_DIRECTORY}/index.rst

--- a/jgt_tools/docs/build_docs.py
+++ b/jgt_tools/docs/build_docs.py
@@ -21,7 +21,6 @@ DOCS_WORKING_DIRECTORY = "_docs"
 
 
 def _build_docs():
-    print(f"Building {PACKAGE_NAME} API docs")
     pyproject = get_pyproject_config()
     tools = pyproject["tool"].get("jgt_tools") or {}
     if "doc_build_types" in tools:

--- a/jgt_tools/docs/build_docs.py
+++ b/jgt_tools/docs/build_docs.py
@@ -3,7 +3,6 @@ import argparse
 import email.utils
 import itertools
 import os
-from pathlib import Path
 import shutil
 import subprocess
 import time
@@ -99,30 +98,6 @@ def build():
     _build_conf()
 
     _build_docs()
-
-    # Copy over all the top level rST files so we don't
-    # have to keep a duplicate list here.
-    for filename in Path().glob("*.rst"):
-        shutil.copy(filename, DOCS_WORKING_DIRECTORY)
-
-    shutil.copy(
-        BASE_DIR / ".jgt_tools.index", BASE_DIR / DOCS_WORKING_DIRECTORY / "index.rst"
-    )
-
-    os.environ["PYTHONPATH"] = str(Path.cwd())
-    subprocess.check_call(
-        [
-            "poetry",
-            "run",
-            "sphinx-build",
-            "-c",
-            DOCS_WORKING_DIRECTORY,
-            "-aEW",
-            DOCS_WORKING_DIRECTORY,
-            DOCS_OUTPUT_DIRECTORY,
-        ],
-        cwd=BASE_DIR,
-    )
 
 
 def push():

--- a/jgt_tools/docs/build_docs.py
+++ b/jgt_tools/docs/build_docs.py
@@ -3,6 +3,7 @@ import argparse
 import email.utils
 import itertools
 import os
+import pathlib
 import shutil
 import subprocess
 import time
@@ -101,7 +102,8 @@ def build():
 
 def push():
     """Push docs to github-pages."""
-    subprocess.check_call(["poetry", "run", "ghp-import", "-p", "docs/"])
+    if (pathlib.Path(BASE_DIR) / DOCS_OUTPUT_DIRECTORY).exists():
+        subprocess.check_call(["poetry", "run", "ghp-import", "-p", "docs/"])
 
 
 def build_and_push():

--- a/jgt_tools/env_setup.py
+++ b/jgt_tools/env_setup.py
@@ -20,6 +20,13 @@ def env_setup(verbose):
     if os.getenv("VIRTUAL_ENV"):
         print(f"Setting up Virtual Environment: {os.environ['VIRTUAL_ENV']}")
     print()
+    # In order to keep the initial install as lean as possible, the base installer only
+    # install the libraries that are needed to run the library itself and all other
+    # libraries are marked as optional. For a user to user the default commands,
+    # additional libraries are needed and so this check first sees if the end user has
+    # *not* modified the default command(s) and if the commands are the default ones,
+    # install those libraries needed by the command. This intentionally cycles over
+    # each command independently in case some are modified and some are not.
     for command in ("build_docs", "run_tests", "env_setup"):
         if DEFAULT_CONFIGS[f"{command}_commands"] == CONFIGS[f"{command}_commands"]:
             __commands_to_run.insert(2, f"poetry run pip install jgt_tools[{command}]")

--- a/jgt_tools/env_setup.py
+++ b/jgt_tools/env_setup.py
@@ -7,7 +7,7 @@ Runs the following commands:
 import argparse
 import os
 
-from .utils import execute_command_list, CONFIGS
+from .utils import execute_command_list, CONFIGS, DEFAULT_CONFIGS
 
 __commands_to_run = CONFIGS["env_setup_commands"]
 
@@ -20,6 +20,9 @@ def env_setup(verbose):
     if os.getenv("VIRTUAL_ENV"):
         print(f"Setting up Virtual Environment: {os.environ['VIRTUAL_ENV']}")
     print()
+    for command in ("build_docs", "run_tests", "env_setup"):
+        if DEFAULT_CONFIGS[f"{command}_commands"] == CONFIGS[f"{command}_commands"]:
+            __commands_to_run.insert(2, f"poetry run pip install jgt_tools[{command}]")
     execute_command_list(__commands_to_run)
 
 

--- a/jgt_tools/utils.py
+++ b/jgt_tools/utils.py
@@ -26,13 +26,13 @@ def execute_command_list(commands_to_run, verbose=True):
             sys.exit(job.returncode)
 
 
-_DEFAULT_CONFIGS: defaultdict = defaultdict(list)
+DEFAULT_CONFIGS: defaultdict = defaultdict(list)
 
 
 def _load_defaults():
     with DEFAULTS_FILE.open() as f:
         for group, cmd in csv.reader(f):
-            _DEFAULT_CONFIGS[group].append(cmd)
+            DEFAULT_CONFIGS[group].append(cmd)
 
 
 _load_defaults()
@@ -75,7 +75,7 @@ def load_configs():
     package_description = poetry["description"]
 
     configs = {
-        **_DEFAULT_CONFIGS,
+        **DEFAULT_CONFIGS,
         "package_name": package_name,
         "description": package_description,
         "base_dir": PACKAGE_ROOT_PATH,

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,23 +2,23 @@
 category = "main"
 description = "A configurable sidebar-enabled Sphinx theme"
 name = "alabaster"
-optional = false
+optional = true
 python-versions = "*"
 version = "0.7.12"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 name = "appdirs"
-optional = false
+optional = true
 python-versions = "*"
 version = "1.4.4"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "A few extensions to pyyaml."
 name = "aspy.yaml"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.3.0"
 
@@ -26,19 +26,19 @@ version = "1.3.0"
 pyyaml = "*"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Atomic file writes."
 marker = "sys_platform == \"win32\""
 name = "atomicwrites"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.4.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Classes Without Boilerplate"
 name = "attrs"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "19.3.0"
 
@@ -52,7 +52,7 @@ tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.i
 category = "main"
 description = "Internationalization utilities"
 name = "babel"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.8.0"
 
@@ -71,15 +71,15 @@ version = "1.5.1"
 category = "main"
 description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
-optional = false
+optional = true
 python-versions = "*"
 version = "2020.6.20"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Validate configuration and produce human readable error messages."
 name = "cfgv"
-optional = false
+optional = true
 python-versions = ">=3.6"
 version = "3.0.0"
 
@@ -87,7 +87,7 @@ version = "3.0.0"
 category = "main"
 description = "Universal encoding detector for Python 2 and 3"
 name = "chardet"
-optional = false
+optional = true
 python-versions = "*"
 version = "3.0.4"
 
@@ -96,15 +96,15 @@ category = "main"
 description = "Cross-platform colored terminal text."
 marker = "sys_platform == \"win32\""
 name = "colorama"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "0.4.3"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Distribution utilities"
 name = "distlib"
-optional = false
+optional = true
 python-versions = "*"
 version = "0.3.1"
 
@@ -112,15 +112,15 @@ version = "0.3.1"
 category = "main"
 description = "Docutils -- Python Documentation Utilities"
 name = "docutils"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "0.16"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "A platform independent file lock."
 name = "filelock"
-optional = false
+optional = true
 python-versions = "*"
 version = "3.0.12"
 
@@ -221,17 +221,17 @@ six = "*"
 category = "main"
 description = "Copy your docs directly to the gh-pages branch."
 name = "ghp-import"
-optional = false
+optional = true
 python-versions = "*"
 version = "0.5.5"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "File identification library for Python"
 name = "identify"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "1.4.25"
+version = "1.4.28"
 
 [package.extras]
 license = ["editdistance"]
@@ -240,7 +240,7 @@ license = ["editdistance"]
 category = "main"
 description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.10"
 
@@ -248,12 +248,12 @@ version = "2.10"
 category = "main"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
 name = "imagesize"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.2.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Read metadata from Python packages"
 marker = "python_version < \"3.8\""
 name = "importlib-metadata"
@@ -269,11 +269,11 @@ docs = ["sphinx", "rst.linker"]
 testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Read resources from Python packages"
 marker = "python_version < \"3.7\""
 name = "importlib-resources"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 version = "3.0.0"
 
@@ -289,7 +289,7 @@ docs = ["sphinx", "rst.linker", "jaraco.packaging"]
 category = "main"
 description = "A very fast and expressive template engine."
 name = "jinja2"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "2.11.2"
 
@@ -303,7 +303,7 @@ i18n = ["Babel (>=0.8)"]
 category = "main"
 description = "Safely add untrusted strings to HTML/XML markup."
 name = "markupsafe"
-optional = false
+optional = true
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 version = "1.1.1"
 
@@ -316,18 +316,18 @@ python-versions = "*"
 version = "0.6.1"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
-optional = false
+optional = true
 python-versions = ">=3.5"
 version = "8.4.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Node.js virtual environment builder"
 name = "nodeenv"
-optional = false
+optional = true
 python-versions = "*"
 version = "1.4.0"
 
@@ -335,7 +335,7 @@ version = "1.4.0"
 category = "main"
 description = "Core utilities for Python packages"
 name = "packaging"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "20.4"
 
@@ -355,10 +355,10 @@ version = "0.8.2"
 flake8-polyfill = ">=1.0.2,<2"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "0.13.1"
 
@@ -371,10 +371,10 @@ version = ">=0.12"
 dev = ["pre-commit", "tox"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 name = "pre-commit"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 version = "1.21.0"
 
@@ -397,10 +397,10 @@ python = "<3.7"
 version = "*"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.9.0"
 
@@ -435,7 +435,7 @@ version = "2.2.0"
 category = "main"
 description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
-optional = false
+optional = true
 python-versions = ">=3.5"
 version = "2.6.1"
 
@@ -443,15 +443,15 @@ version = "2.6.1"
 category = "main"
 description = "Python parsing module"
 name = "pyparsing"
-optional = false
+optional = true
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "2.4.7"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "pytest: simple powerful testing with Python"
 name = "pytest"
-optional = false
+optional = true
 python-versions = ">=3.5"
 version = "5.4.3"
 
@@ -477,15 +477,15 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 category = "main"
 description = "World timezone definitions, modern and historical"
 name = "pytz"
-optional = false
+optional = true
 python-versions = "*"
 version = "2020.1"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "YAML parser and emitter for Python"
 name = "pyyaml"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "5.3.1"
 
@@ -493,7 +493,7 @@ version = "5.3.1"
 category = "main"
 description = "Python HTTP for Humans."
 name = "requests"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "2.24.0"
 
@@ -527,15 +527,15 @@ version = "2.0.0"
 category = "main"
 description = "Python documentation generator"
 name = "sphinx"
-optional = false
+optional = true
 python-versions = ">=3.5"
-version = "2.4.4"
+version = "3.2.1"
 
 [package.dependencies]
 Jinja2 = ">=2.3"
 Pygments = ">=2.0"
 alabaster = ">=0.7,<0.8"
-babel = ">=1.3,<2.0 || >2.0"
+babel = ">=1.3"
 colorama = ">=0.3.5"
 docutils = ">=0.12"
 imagesize = "*"
@@ -552,24 +552,28 @@ sphinxcontrib-serializinghtml = "*"
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-test = ["pytest (<5.3.3)", "pytest-cov", "html5lib", "flake8 (>=3.5.0)", "flake8-import-order", "mypy (>=0.761)", "docutils-stubs"]
+lint = ["flake8 (>=3.5.0)", "flake8-import-order", "mypy (>=0.780)", "docutils-stubs"]
+test = ["pytest", "pytest-cov", "html5lib", "typed-ast", "cython"]
 
 [[package]]
 category = "main"
 description = "Read the Docs theme for Sphinx"
 name = "sphinx-rtd-theme"
-optional = false
+optional = true
 python-versions = "*"
-version = "0.4.3"
+version = "0.5.0"
 
 [package.dependencies]
 sphinx = "*"
+
+[package.extras]
+dev = ["transifex-client", "sphinxcontrib-httpdomain", "bump2version"]
 
 [[package]]
 category = "main"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
 name = "sphinxcontrib-applehelp"
-optional = false
+optional = true
 python-versions = ">=3.5"
 version = "1.0.2"
 
@@ -581,7 +585,7 @@ test = ["pytest"]
 category = "main"
 description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
 name = "sphinxcontrib-devhelp"
-optional = false
+optional = true
 python-versions = ">=3.5"
 version = "1.0.2"
 
@@ -593,7 +597,7 @@ test = ["pytest"]
 category = "main"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 name = "sphinxcontrib-htmlhelp"
-optional = false
+optional = true
 python-versions = ">=3.5"
 version = "1.0.3"
 
@@ -605,7 +609,7 @@ test = ["pytest", "html5lib"]
 category = "main"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
 name = "sphinxcontrib-jsmath"
-optional = false
+optional = true
 python-versions = ">=3.5"
 version = "1.0.1"
 
@@ -616,7 +620,7 @@ test = ["pytest", "flake8", "mypy"]
 category = "main"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
 name = "sphinxcontrib-qthelp"
-optional = false
+optional = true
 python-versions = ">=3.5"
 version = "1.0.3"
 
@@ -628,7 +632,7 @@ test = ["pytest"]
 category = "main"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
 name = "sphinxcontrib-serializinghtml"
-optional = false
+optional = true
 python-versions = ">=3.5"
 version = "1.1.4"
 
@@ -637,10 +641,10 @@ lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
-optional = false
+optional = true
 python-versions = "*"
 version = "0.10.1"
 
@@ -649,14 +653,14 @@ category = "main"
 description = "Style preserving TOML library"
 name = "tomlkit"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.5.11"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.7.0"
 
 [[package]]
 category = "main"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 version = "1.25.10"
 
@@ -666,12 +670,12 @@ secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Virtual Python Environment builder"
 name = "virtualenv"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.0.28"
+version = "20.0.31"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
@@ -692,15 +696,15 @@ docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sp
 testing = ["coverage (>=5)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "pytest-xdist (>=1.31.0)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Measures the displayed width of unicode strings in a terminal"
 name = "wcwidth"
-optional = false
+optional = true
 python-versions = "*"
 version = "0.2.5"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 marker = "python_version < \"3.8\""
 name = "zipp"
@@ -714,9 +718,11 @@ testing = ["jaraco.itertools", "func-timeout"]
 
 [extras]
 build_docs = ["sphinx", "sphinx-rtd-theme", "ghp-import"]
+env_setup = ["pre-commit"]
+run_tests = ["pytest"]
 
 [metadata]
-content-hash = "b6be9f0b085d80c81dedf15d32836493a9d1ddab7cd707f835672cdf27015c36"
+content-hash = "6fc37c165fd203b5dc6af9994251df7f5a905ba8658ca20ebdc173c940e8a1ba"
 lock-version = "1.0"
 python-versions = "^3.6"
 
@@ -807,8 +813,8 @@ ghp-import = [
     {file = "ghp-import-0.5.5.tar.gz", hash = "sha256:3e924ea720e4e1f82d56753db2154bfb86067472c5830732159c3a4c4fbc75d7"},
 ]
 identify = [
-    {file = "identify-1.4.25-py2.py3-none-any.whl", hash = "sha256:ccd88716b890ecbe10920659450a635d2d25de499b9a638525a48b48261d989b"},
-    {file = "identify-1.4.25.tar.gz", hash = "sha256:110ed090fec6bce1aabe3c72d9258a9de82207adeaa5a05cd75c635880312f9a"},
+    {file = "identify-1.4.28-py2.py3-none-any.whl", hash = "sha256:69c4769f085badafd0e04b1763e847258cbbf6d898e8678ebffc91abdb86f6c6"},
+    {file = "identify-1.4.28.tar.gz", hash = "sha256:d6ae6daee50ba1b493e9ca4d36a5edd55905d2cf43548fdc20b2a14edef102e7"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -950,12 +956,12 @@ snowballstemmer = [
     {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
 ]
 sphinx = [
-    {file = "Sphinx-2.4.4-py3-none-any.whl", hash = "sha256:fc312670b56cb54920d6cc2ced455a22a547910de10b3142276495ced49231cb"},
-    {file = "Sphinx-2.4.4.tar.gz", hash = "sha256:b4c750d546ab6d7e05bdff6ac24db8ae3e8b8253a3569b754e445110a0a12b66"},
+    {file = "Sphinx-3.2.1-py3-none-any.whl", hash = "sha256:ce6fd7ff5b215af39e2fcd44d4a321f6694b4530b6f2b2109b64d120773faea0"},
+    {file = "Sphinx-3.2.1.tar.gz", hash = "sha256:321d6d9b16fa381a5306e5a0b76cd48ffbc588e6340059a729c6fdd66087e0e8"},
 ]
 sphinx-rtd-theme = [
-    {file = "sphinx_rtd_theme-0.4.3-py2.py3-none-any.whl", hash = "sha256:00cf895504a7895ee433807c62094cf1e95f065843bf3acd17037c3e9a2becd4"},
-    {file = "sphinx_rtd_theme-0.4.3.tar.gz", hash = "sha256:728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a"},
+    {file = "sphinx_rtd_theme-0.5.0-py2.py3-none-any.whl", hash = "sha256:373413d0f82425aaa28fb288009bf0d0964711d347763af2f1b65cafcb028c82"},
+    {file = "sphinx_rtd_theme-0.5.0.tar.gz", hash = "sha256:22c795ba2832a169ca301cd0a083f7a434e09c538c70beb42782c073651b707d"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
@@ -986,16 +992,16 @@ toml = [
     {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
 ]
 tomlkit = [
-    {file = "tomlkit-0.5.11-py2.py3-none-any.whl", hash = "sha256:4e1bd6c9197d984528f9ff0cc9db667c317d8881288db50db20eeeb0f6b0380b"},
-    {file = "tomlkit-0.5.11.tar.gz", hash = "sha256:f044eda25647882e5ef22b43a1688fb6ab12af2fc50e8456cdfc751c873101cf"},
+    {file = "tomlkit-0.7.0-py2.py3-none-any.whl", hash = "sha256:6babbd33b17d5c9691896b0e68159215a9387ebfa938aa3ac42f4a4beeb2b831"},
+    {file = "tomlkit-0.7.0.tar.gz", hash = "sha256:ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"},
 ]
 urllib3 = [
     {file = "urllib3-1.25.10-py2.py3-none-any.whl", hash = "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"},
     {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.0.28-py2.py3-none-any.whl", hash = "sha256:8f582a030156282a9ee9d319984b759a232b07f86048c1d6a9e394afa44e78c8"},
-    {file = "virtualenv-20.0.28.tar.gz", hash = "sha256:688a61d7976d82b92f7906c367e83bb4b3f0af96f8f75bfcd3da95608fe8ac6c"},
+    {file = "virtualenv-20.0.31-py2.py3-none-any.whl", hash = "sha256:e0305af10299a7fb0d69393d8f04cb2965dda9351140d11ac8db4e5e3970451b"},
+    {file = "virtualenv-20.0.31.tar.gz", hash = "sha256:43add625c53c596d38f971a465553f6318decc39d98512bc100fa1b1e839c8dc"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jgt_tools"
-version = "0.3.2"
+version = "0.4.0"
 description = "A collection of tools for commmon package scripts"
 authors = ["Brad Brown <brad@bradsbrown.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,14 @@ repository = "https://github.com/jolly-good-toolbelt/jgt_tools"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-tomlkit = "^0.5.3"
-sphinx = {version = "^2.1", optional = true}
-sphinx-rtd-theme = {version = "^0.4.3", optional = true}
+tomlkit = "^0.7.0"
+sphinx = {version = "^3.1.2", optional = true}
+sphinx-rtd-theme = {version = "^0.5.0", optional = true}
 ghp-import = {version = "^0.5.5", optional = true}
+pytest = {version = "^5.0", optional = true}
+pre-commit = {version = "^1.15", optional = true}
 
 [tool.poetry.dev-dependencies]
-pre-commit = "^1.15"
 flake8 = "^3.7"
 flake8-builtins = "^1.4"
 flake8-comprehensions = "^2.1"
@@ -25,13 +26,11 @@ flake8-docstrings = "^1.3"
 flake8-tuple = "^0.4.0"
 flake8-quotes = "^2.0"
 pep8-naming = "^0.8.2"
-sphinx = "^2.1"
-sphinx-rtd-theme = "^0.4.3"
-ghp-import = "^0.5.5"
-pytest = "^5.0"
 
 [tool.poetry.extras]
 build_docs = ["sphinx", "sphinx-rtd-theme", "ghp-import"]
+run_tests = ["pytest"]
+env_setup = ["pre-commit"]
 
 [tool.poetry.scripts]
 run-tests = "jgt_tools.run_tests:main"
@@ -42,5 +41,5 @@ build-docs = {callable = "jgt_tools.docs.build_docs:build", extras = ["build_doc
 build-and-push-docs = {callable = "jgt_tools.docs.build_docs:build_and_push", extras = ["build_docs"]}
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=1.0"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Since `pytest`, `pre-commit`, and `sphinx` are needed if the user wants to use the default commands, setup the environment such that they are not installed by default but at setup are installed if the default commands are left in tact.