### PR TITLE
Enhancement: Support Non-Sphinx Build Docs

### DIFF
--- a/jgt_tools/docs/build_docs.py
+++ b/jgt_tools/docs/build_docs.py
@@ -13,7 +13,7 @@ from ..utils import (
     CONFIGS,
     execute_command_list,
     get_pyproject_config,
-    default_commands,
+    has_default_commands,
 )
 from .sample_conf import CONF_PY, MARKDOWN, TYPE_HINTS
 
@@ -98,7 +98,7 @@ def build():
         itertools.chain(poetry["dependencies"], poetry["dev-dependencies"])
     )
 
-    if default_commands("build_docs") or "sphinx" in dependencies:
+    if has_default_commands("build_docs") or "sphinx" in dependencies:
         _build_conf(poetry, dependencies)
 
     _build_docs(pyproject)

--- a/jgt_tools/env_setup.py
+++ b/jgt_tools/env_setup.py
@@ -7,7 +7,7 @@ Runs the following commands:
 import argparse
 import os
 
-from .utils import execute_command_list, CONFIGS, DEFAULT_CONFIGS
+from .utils import execute_command_list, CONFIGS, default_commands
 
 __commands_to_run = CONFIGS["env_setup_commands"]
 
@@ -28,7 +28,7 @@ def env_setup(verbose):
     # install those libraries needed by the command. This intentionally cycles over
     # each command independently in case some are modified and some are not.
     for command in ("build_docs", "run_tests", "env_setup"):
-        if DEFAULT_CONFIGS[f"{command}_commands"] == CONFIGS[f"{command}_commands"]:
+        if default_commands(command):
             __commands_to_run.insert(2, f"poetry run pip install jgt_tools[{command}]")
     execute_command_list(__commands_to_run)
 

--- a/jgt_tools/env_setup.py
+++ b/jgt_tools/env_setup.py
@@ -7,7 +7,7 @@ Runs the following commands:
 import argparse
 import os
 
-from .utils import execute_command_list, CONFIGS, default_commands
+from .utils import execute_command_list, CONFIGS, has_default_commands
 
 __commands_to_run = CONFIGS["env_setup_commands"]
 
@@ -28,7 +28,7 @@ def env_setup(verbose):
     # install those libraries needed by the command. This intentionally cycles over
     # each command independently in case some are modified and some are not.
     for command in ("build_docs", "run_tests", "env_setup"):
-        if default_commands(command):
+        if has_default_commands(command):
             __commands_to_run.insert(2, f"poetry run pip install jgt_tools[{command}]")
     execute_command_list(__commands_to_run)
 

--- a/jgt_tools/utils.py
+++ b/jgt_tools/utils.py
@@ -113,3 +113,17 @@ def owner_name_from(origin_url):
     owner_name = owner_name.rsplit(".", 1)[0]  # Remove `.git`
     # Keep only the last two parts that remain, which are the org/owner and repo name
     return "/".join(owner_name.split("/")[-2:])
+
+
+def default_commands(command):
+    """
+    Check if the provided command is the default list.
+
+    Args:
+        command: Command to check. One of ('build_docs', 'run_tests', or 'env_setup')
+
+    Returns:
+        bool: True if the commands are default, otherwise false
+
+    """
+    return DEFAULT_CONFIGS[f"{command}_commands"] == CONFIGS[f"{command}_commands"]

--- a/jgt_tools/utils.py
+++ b/jgt_tools/utils.py
@@ -115,7 +115,7 @@ def owner_name_from(origin_url):
     return "/".join(owner_name.split("/")[-2:])
 
 
-def default_commands(command):
+def has_default_commands(command):
     """
     Check if the provided command is the default list.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jgt_tools"
-version = "0.4.0"
+version = "0.5.0"
 description = "A collection of tools for commmon package scripts"
 authors = ["Brad Brown <brad@bradsbrown.com>"]
 license = "MIT"


### PR DESCRIPTION
The `build-docs` command creates a conf.py regardless of which commands
are actually being run, which can leave a project with an unneeded file
in the repository. This enhancement checks to see if Sphinx is being
used before attempting to build the conf file.