### PR TITLE
Enhancement: Allow KeyboardInterrupt

### DIFF
--- a/jgt_tools/utils.py
+++ b/jgt_tools/utils.py
@@ -21,9 +21,12 @@ def execute_command_list(commands_to_run, verbose=True):
     for command in commands_to_run:
         if verbose:
             print(f"+{command}")
-        job = subprocess.run(shlex.split(command), cwd=CONFIGS["base_dir"])
-        if job.returncode:
-            sys.exit(job.returncode)
+        try:
+            job = subprocess.run(shlex.split(command), cwd=CONFIGS["base_dir"])
+            if job.returncode:
+                sys.exit(job.returncode)
+        except KeyboardInterrupt:
+            pass
 
 
 DEFAULT_CONFIGS: defaultdict = defaultdict(list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jgt_tools"
-version = "0.4.0"
+version = "0.4.1"
 description = "A collection of tools for commmon package scripts"
 authors = ["Brad Brown <brad@bradsbrown.com>"]
 license = "MIT"


### PR DESCRIPTION
When running some commands, the command could actually include an event
loop that waits for a user to exit (e.g., `sphinx-autobuild`). Right
now, when the user exits out via Ctrl+C, a nasty traceback is displayed.
This change will catch that error so that it is not shown to the user.