### PR TITLE
Bugfix: Find Default Branch

### DIFF
--- a/jgt_tools/check_version.py
+++ b/jgt_tools/check_version.py
@@ -11,14 +11,32 @@ def _version_changed(pyproject_diff):
     return "+version = " in pyproject_diff
 
 
+def find_default_branch():
+    """Find the default branch for a git repository."""
+    remotes = subprocess.check_output(
+        ["git", "remote"], universal_newlines=True
+    ).splitlines()
+    if len(remotes) == 1:
+        remote = remotes[0]
+    elif "origin" in remotes:
+        remote = "origin"
+    else:
+        raise KeyError("Cannot determine remote")
+    remote_info = subprocess.check_output(
+        ["git", "remote", "show", remote], universal_newlines=True
+    ).splitlines()
+    return [x for x in remote_info if "HEAD branch" in x][0].split(":")[1].strip()
+
+
 def check_version():
     """Verify the version is changed if any code files are changed."""
+    default_branch = find_default_branch()
     changed_files = subprocess.check_output(
-        ["git", "diff", "master", "--name-only"], universal_newlines=True
+        ["git", "diff", default_branch, "--name-only"], universal_newlines=True
     ).splitlines()
 
     pyproject_diff = subprocess.check_output(
-        ["git", "diff", "master", "pyproject.toml"], universal_newlines=True
+        ["git", "diff", default_branch, "pyproject.toml"], universal_newlines=True
     )
 
     check_file_changes = _any_py_files_changed

--- a/jgt_tools/check_version.py
+++ b/jgt_tools/check_version.py
@@ -11,17 +11,21 @@ def _version_changed(pyproject_diff):
     return "+version = " in pyproject_diff
 
 
-def find_default_branch():
-    """Find the default branch for a git repository."""
+def find_remote():
+    """Find the primary remote for a git repository."""
     remotes = subprocess.check_output(
         ["git", "remote"], universal_newlines=True
     ).splitlines()
     if len(remotes) == 1:
-        remote = remotes[0]
+        return remotes[0]
     elif "origin" in remotes:
-        remote = "origin"
-    else:
-        raise KeyError("Cannot determine remote")
+        return "origin"
+    raise KeyError("Cannot determine remote")
+
+
+def find_default_branch():
+    """Find the default branch for a git repository."""
+    remote = find_remote()
     remote_info = subprocess.check_output(
         ["git", "remote", "show", remote], universal_newlines=True
     ).splitlines()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jgt_tools"
-version = "0.4.0"
+version = "0.4.2"
 description = "A collection of tools for commmon package scripts"
 authors = ["Brad Brown <brad@bradsbrown.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [tool.poetry]
 name = "jgt_tools"
 version = "0.4.2"
-version = "0.4.1"
 description = "A collection of tools for commmon package scripts"
 authors = ["Brad Brown <brad@bradsbrown.com>"]
 license = "MIT"


### PR DESCRIPTION
The code assumed that `master` was the default branch name, when that is
not guaranteed to be true, especially as more hosts are moving to making
`main` the default branch name.