### PR TITLE
Support actions more robustly 

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,7 +1,7 @@
 name: publish-docs
 on:
   push:
-    branches: [main]
+    branches: [master]
 jobs:
   publish-docs:
     runs-on: ubuntu-latest
@@ -29,7 +29,8 @@ jobs:
 
       - name: Install App and Dependencies
         if: steps.poetry-cache.outputs.cache-hit != 'true'
-        run: python env_setup.py
+        # checks should install the local versions not, what's currently released
+        run: poetry install --extras "env_setup run_tests build_docs"
 
       - name: Build Docs
         run: poetry run build-docs

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install App and Dependencies
         if: steps.poetry-cache.outputs.cache-hit != 'true'
         # checks should install the local versions not, what's currently released
-        run: poetry install --extras "env_setup run_tests build_docs"
+        run: poetry install --extras "build_docs"
 
       - name: Build Docs
         run: poetry run build-docs

--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -1,7 +1,7 @@
 name: publish-library
 on:
   push:
-    branches: [main]
+    branches: [master]
 jobs:
   publish-library:
     runs-on: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install App and Dependencies
         if: steps.poetry-cache.outputs.cache-hit != 'true'
-        run: python env_setup.py
+        run: poetry install
 
       - name: Publish Library
         run: poetry publish -u ${{ secrets.PYPI_USER }} -p ${{ secrets.PYPI_PASS }} --build

--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -29,7 +29,8 @@ jobs:
 
       - name: Install App and Dependencies
         if: steps.poetry-cache.outputs.cache-hit != 'true'
-        run: python env_setup.py
+        # checks should install the local versions not, what's currently released
+        run: poetry install --extras "env_setup run_tests build_docs"
 
       - name: Run Checks
         run: |

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/jgt_tools/check_version.py
+++ b/jgt_tools/check_version.py
@@ -47,11 +47,12 @@ def check_default_branch(default_branch):
 def check_version():
     """Verify the version is changed if any code files are changed."""
     default_branch = find_default_branch()
-    if os.getenv("GITHUB_ACTIONS") == "true":
-        changed_files, pyproject_diff = check_default_branch(f"origin/{default_branch}")
-    else:
-        changed_files, pyproject_diff = check_default_branch(default_branch)
-
+    default_branch = (
+        f"origin/{default_branch}"
+        if os.getenv("GITHUB_ACTIONS") == "true"
+        else default_branch
+    )
+    changed_files, pyproject_diff = check_default_branch(default_branch)
     check_file_changes = _any_py_files_changed
     for entry in pkg_resources.iter_entry_points("file_checkers"):
         if entry.name == "version_trigger":

--- a/jgt_tools/check_version.py
+++ b/jgt_tools/check_version.py
@@ -47,11 +47,9 @@ def check_default_branch(default_branch):
 def check_version():
     """Verify the version is changed if any code files are changed."""
     default_branch = find_default_branch()
-    default_branch = (
-        f"origin/{default_branch}"
-        if os.getenv("GITHUB_ACTIONS") == "true"
-        else default_branch
-    )
+    # if the check is running in github actions, we need to use the remote ref
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        default_branch = f"origin/{default_branch}"
     changed_files, pyproject_diff = check_default_branch(default_branch)
     check_file_changes = _any_py_files_changed
     for entry in pkg_resources.iter_entry_points("file_checkers"):

--- a/jgt_tools/check_version.py
+++ b/jgt_tools/check_version.py
@@ -32,7 +32,9 @@ def find_default_branch():
     ).splitlines()
     return [x for x in remote_info if "HEAD branch" in x][0].split(":")[1].strip()
 
+
 def check_default_branch(default_branch):
+    """Get changed files and pyproject.toml diff for a branch."""
     changed_files = subprocess.check_output(
         ["git", "diff", default_branch, "--name-only"], universal_newlines=True
     ).splitlines()
@@ -41,16 +43,14 @@ def check_default_branch(default_branch):
     )
     return changed_files, pyproject_diff
 
+
 def check_version():
     """Verify the version is changed if any code files are changed."""
     default_branch = find_default_branch()
-    # it seems like getting the master branch available in actions is actually rather difficult,
-    # however, origin master should be good. It may be ok just to do this even when running locally.
     if os.getenv("GITHUB_ACTIONS") == "true":
         changed_files, pyproject_diff = check_default_branch(f"origin/{default_branch}")
     else:
         changed_files, pyproject_diff = check_default_branch(default_branch)
-
 
     check_file_changes = _any_py_files_changed
     for entry in pkg_resources.iter_entry_points("file_checkers"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jgt_tools"
-version = "0.5.0"
+version = "0.5.1"
 description = "A collection of tools for commmon package scripts"
 authors = ["Brad Brown <brad@bradsbrown.com>"]
 license = "MIT"


### PR DESCRIPTION
After working through some of the kinks to get actions setup on jolly-good-toolbelt/sphinx_gherkindoc/pull/52, I realized that a change needed to be made here. 

Summary of changes:

* Support `origin/master` for check_version.
  * In actions, the only way to get a local checkout of "master" is to checkout master and then checkout the branch again - this seems a little cumbersome, so I added a check for the `GITHUB_ACTIONS` envvar. [See details here](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables). 
  * Another possible way of handling this is to just always check against `origin/[default]` since the point is to compare what's currently released, which should always be compared with remote anyway. Would appreciate your thoughts.
* Update workflows to run poetry install with extras as opposed to running env_setup.py. 
  * The env_setup script that's fetched in jolly-good-toolbelt/sphinx_gherkindoc/pull/52 (and as being run here) is always going to install what's currently released. In order to properly check the changes here locally, it _probably_ makes sense to just run poetry install with the optional packages as 'extra' args. 
  * The downstream implications could be to simply update the dev dependency of jgt_tools in downstream packages to just use the `extras` arguement in the pyproject.yaml. I created [a PR in my own fork](https://github.com/dsayling/sphinx_gherkindoc/pull/2/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R27) to demonstrate. Here is [the resulting action](https://github.com/dsayling/sphinx_gherkindoc/runs/4585861465?check_suite_focus=true).
